### PR TITLE
Add folder for GDR Data Lake tutorial notebooks

### DIFF
--- a/GDR Data Lake Tutorial Notebooks/README.md
+++ b/GDR Data Lake Tutorial Notebooks/README.md
@@ -1,0 +1,1 @@
+This folder contains tutorial notebooks for data stored in the GDR Data Lake in S3.

--- a/GDR Data Lake Tutorial Notebooks/README.md
+++ b/GDR Data Lake Tutorial Notebooks/README.md
@@ -1,1 +1,0 @@
-This folder contains tutorial notebooks for data stored in the GDR Data Lake in S3.


### PR DESCRIPTION
Added a folder for tutorial notebooks related to datasets in the gdr-data-lake bucket. There are a few on the way so want to keep things organized.